### PR TITLE
Nptyping for types only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,12 +52,13 @@ jobs:
         run: uv run pre-commit run --all-files
 
   tox_tests:
-    name: Tox Tests (${{ matrix.python-version }}) # Add python version to name for clarity
+    name: Tox Tests (Python ${{ matrix.python-version }}, NumPy ${{ matrix.numpy-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-      fail-fast: true # Optional: prevent other matrix jobs from cancelling if one fails
+        numpy-version: ["1.25.0", "1.26.0", "2.0.0", "2.1.0", "2.2.0", "2.3.0"]
+      fail-fast: false # Changed to false so you can see all failures
     steps:
       - uses: actions/checkout@v4
 
@@ -79,13 +80,13 @@ jobs:
       - name: Install Tox with tox-uv plugin using UV
         run: uv tool install tox --with tox-uv
 
-      # Run Tox using uvx
-      # uvx ensures that the 'tox' command installed via 'uv tool install' is used
+      # Run Tox using uvx with numpy version as environment variable
       - name: Run Tox tests via uvx
         run: |
           PY_VERSION=$(echo ${{ matrix.python-version }} | tr -d '.')
           uvx tox -e py$PY_VERSION
-
+        env:
+          NUMPY_VERSION: ${{ matrix.numpy-version }}
 
   build:
     needs: [rust_checks_and_python_tests, tox_tests]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,23 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         numpy-version: ["1.25.0", "1.26.0", "2.0.0", "2.1.0", "2.2.0", "2.3.0"]
+        exclude:
+          # These combinations of python and numpy versions are incompatible
+          - python-version: "3.9"
+            numpy-version: "2.1.0"
+          - python-version: "3.9"
+            numpy-version: "2.2.0"
+          - python-version: "3.9"
+            numpy-version: "2.3.0"
+          - python-version: "3.10"
+            numpy-version: "2.3.0"
+          - python-version: "3.12"
+            numpy-version: "1.25.0"
+          - python-version: "3.13"
+            numpy-version: "1.25.0"
+          - python-version: "3.13"
+            numpy-version: "1.26.0"
+
       fail-fast: false # Changed to false so you can see all failures
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,14 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
-dependencies = ["nptyping==2.5.0", "numpy>1.25.0"]
+dependencies = [
+ "numpy>1.25.0",
+]
+
+[project.optional-dependencies]
+types = [
+    "nptyping==2.5.0",
+]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/python/mergechannels/__init__.pyi
+++ b/python/mergechannels/__init__.pyi
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Literal, Sequence, Union
-from nptyping import NDArray, Shape, UInt8
 import numpy as np
 
 from mergechannels._blending import BLENDING_OPTIONS
@@ -9,6 +8,11 @@ from mergechannels._luts import COLORMAPS
 if TYPE_CHECKING:
     from matplotlib.colors import Colormap as MatplotlibColormap
     from cmap import Colormap as CmapColormap
+    from nptyping import (
+        NDArray,
+        Shape,
+        UInt8,
+    )
 
 
 Number = Union[int, float]

--- a/python/mergechannels/_internal.py
+++ b/python/mergechannels/_internal.py
@@ -7,11 +7,6 @@ from typing import (
 )
 
 import numpy as np
-from nptyping import (
-	NDArray,
-	Shape,
-	UInt8,
-)
 
 from mergechannels import (
 	dispatch_single_channel,
@@ -23,6 +18,11 @@ from ._blending import BLENDING_OPTIONS
 if TYPE_CHECKING:
 	from matplotlib.colors import Colormap as MatplotlibColormap
 	from cmap import Colormap as CmapColormap
+	from nptyping import (
+		NDArray,
+		Shape,
+		UInt8,
+	)
 
 def _parse_cmap_arguments(
     color: Union[

--- a/python/mergechannels/_internal.py
+++ b/python/mergechannels/_internal.py
@@ -56,7 +56,11 @@ def _parse_cmap_arguments(
 			except AttributeError:  # must be a list of lists or an array castable to u8 (256, 3)
 				cmap_values = np.asarray(color).astype('uint8')  # type: ignore
 
-	if not isinstance(cmap_values, NDArray[Shape['256, 3'], UInt8]):  # type: ignore
+	if not (
+		isinstance(cmap_values, np.ndarray)
+		and cmap_values.shape == (256, 3)
+		and cmap_values.dtype == np.uint8
+	):
 		raise ValueError(
 			'Expected a matplotlib colormap, a cmaps colormap, or an object directly castable to '
 				f'an 8-bit array of shape (256, 3), got {type(cmap_values)}: {color}'

--- a/src/cmaps.rs
+++ b/src/cmaps.rs
@@ -6,7 +6,7 @@ type Colormap = [[u8; 3]; 256];
 pub fn load_cmap(cmap_name: &str) -> &[[u8; 3]; 256] {
     CMAPS
         .get(cmap_name)
-        .unwrap_or_else(|| panic!("Invalid colormap name: {}", cmap_name))
+        .unwrap_or_else(|| panic!("Invalid colormap name: {cmap_name}"))
 }
 
 lazy_static! {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,10 +12,10 @@ impl std::fmt::Display for DispatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DispatchError::UnsupportedDataType(dtype) => {
-                write!(f, "Received unsupported dtype: {}", dtype)
+                write!(f, "Received unsupported dtype: {dtype}")
             }
             DispatchError::UnsupportedNumberOfDimensions(ndim) => {
-                write!(f, "Received unsupported number of dimensions: {}", ndim)
+                write!(f, "Received unsupported number of dimensions: {ndim}")
             }
         }
     }
@@ -40,8 +40,7 @@ impl std::fmt::Display for MergeError {
             MergeError::InvalidBlendingMode(mode) => {
                 write!(
                     f,
-                    "Invalid blending mode: `{}`. Valid modes are 'max', 'sum', 'min', and 'mean'.",
-                    mode
+                    "Invalid blending mode: `{mode}`. Valid modes are 'max', 'sum', 'min', and 'mean'."
                 )
             }
         }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -82,8 +82,7 @@ where
     let (first, rest) = dtypes.split_first().ok_or("No dtypes found".to_string())?;
     if !rest.iter().all(|dtype| dtype == first) {
         return Err(format!(
-            "Expected all arrays to have the same dtype, got {:?}",
-            dtypes
+            "Expected all arrays to have the same dtype, got {dtypes:?}"
         ));
     }
     Ok(first)

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ isolated_build = True
 
 [testenv]
 deps =
+    numpy=={env:NUMPY_VERSION:latest}
     cmap
     pytest
     matplotlib

--- a/uv.lock
+++ b/uv.lock
@@ -505,8 +505,12 @@ wheels = [
 name = "mergechannels"
 source = { editable = "." }
 dependencies = [
-    { name = "nptyping" },
     { name = "numpy" },
+]
+
+[package.optional-dependencies]
+types = [
+    { name = "nptyping" },
 ]
 
 [package.dev-dependencies]
@@ -522,9 +526,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "nptyping", specifier = "==2.5.0" },
+    { name = "nptyping", marker = "extra == 'types'", specifier = "==2.5.0" },
     { name = "numpy", specifier = ">1.25.0" },
 ]
+provides-extras = ["types"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
The [nptyping](https://github.com/ramonhagenaars/nptyping) package isn't being actively maintained and is currently incompatible with numpy 2.0+. This package should be compatible with any reasonably recent numpy version. This release makes nptyping an optional dependency and uses it for type hints only. It also adds explicit tests for compatibility with all versions of numpy between `1.25.0` and `2.3.0`.