### PR TITLE
Allow up to 8 channels

### DIFF
--- a/src/blend.rs
+++ b/src/blend.rs
@@ -1,6 +1,6 @@
 use smallvec::SmallVec;
 
-pub const MAX_N_CH: usize = 12;
+pub const MAX_N_CH: usize = 8;
 
 pub type BlendFn = fn(&SmallVec<[[u8; 3]; MAX_N_CH]>) -> [u8; 3];
 


### PR DESCRIPTION
Ran several benchmarks and settled on a maximum of 8 channels as being more than sufficient without sacrificing performance. 