### PR TITLE
Add boundaries filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "mergechannels"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ndarray",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mergechannels"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ c.imshow(
         color='Grays',  # colormap for the image
         masks=[bright_nuclei_masks, dim_nuclei_masks],  # overlay each mask array individually
         mask_colors=['betterOrange', 'betterBlue'],  # the max value of these cmaps are used
-        mask_alphas=[0.8, 0.2],  # show bright nuclei in bold, dim nuclei or faded
+        mask_alphas=[0.8, 0.2],  # show bright nuclei in bold while dim nuclei are faded
         boundaries_only=[True, False]  # show outlines of bright nuclei, whole-masks for dim nuclei
     )
 )  # add mask overlay

--- a/pytests/test_boundaries_only.py
+++ b/pytests/test_boundaries_only.py
@@ -95,3 +95,186 @@ class TestBoundariesOnly3DWarning:
                 saturation_limits=(0, 255),
                 boundaries_only=True,
             )
+
+    def test_apply_color_map_3d_warning_with_list(self):
+        """apply_color_map should warn when any boundaries_only value is True with 3D array."""
+        arr = np.random.randint(0, 256, (5, 64, 64), dtype=np.uint8)
+        mask1 = np.zeros((5, 64, 64), dtype=np.bool_)
+        mask1[:, 10:30, 10:30] = True
+        mask2 = np.zeros((5, 64, 64), dtype=np.bool_)
+        mask2[:, 30:50, 30:50] = True
+
+        with pytest.warns(
+            UserWarning,
+            match='boundaries_only=True is not supported for 3D arrays',
+        ):
+            mc.apply_color_map(
+                arr,
+                'Grays',
+                saturation_limits=(0, 255),
+                masks=[mask1, mask2],
+                boundaries_only=[False, True],  # Only second mask has boundaries
+            )
+
+
+class TestBoundariesOnlyPerMask:
+    """Test per-mask boundaries_only functionality."""
+
+    def test_apply_color_map_per_mask_boundaries(self):
+        """apply_color_map with per-mask boundaries_only list."""
+        arr = np.zeros((64, 64), dtype=np.uint8)
+        arr[20:44, 20:44] = 128
+
+        # First mask: full overlay (solid square)
+        mask1 = np.zeros((64, 64), dtype=np.bool_)
+        mask1[10:20, 10:20] = True
+
+        # Second mask: boundary only (should only show edges)
+        mask2 = np.zeros((64, 64), dtype=np.int32)
+        mask2[30:50, 30:50] = 1
+
+        rgb = mc.apply_color_map(
+            arr,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask1, mask2],
+            mask_colors=['#FF0000', '#00FF00'],
+            boundaries_only=[False, True],  # First full, second boundary-only
+        )
+
+        assert rgb.shape == (64, 64, 3)
+        assert rgb.dtype == np.uint8
+
+        # First mask region (10:20, 10:20) should have red overlay (full)
+        # Check center of first mask - should be affected by red
+        assert rgb[15, 15, 0] > 0  # Red channel should be affected
+
+        # To verify boundaries_only works, compare with full mask overlay
+        rgb_full = mc.apply_color_map(
+            arr,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask1, mask2],
+            mask_colors=['#FF0000', '#00FF00'],
+            boundaries_only=[False, False],  # Both full overlays
+        )
+
+        # Interior of second mask should differ: boundary-only has no green, full has green
+        # The interior point (40,40) should have MORE green in the full overlay version
+        assert rgb_full[40, 40, 1] > rgb[40, 40, 1]  # Full has more green in interior
+
+        # Boundary should be the same in both cases
+        assert rgb[30, 40, 1] == rgb_full[30, 40, 1]  # Top edge same in both
+
+    def test_merge_per_mask_boundaries(self):
+        """merge with per-mask boundaries_only list."""
+        arr1 = np.zeros((64, 64), dtype=np.uint8)
+        arr1[20:44, 20:44] = 128
+        arr2 = np.zeros((64, 64), dtype=np.uint8)
+        arr2[10:54, 10:54] = 100
+
+        # First mask: boundary only
+        mask1 = np.zeros((64, 64), dtype=np.bool_)
+        mask1[5:15, 5:15] = True
+
+        # Second mask: full overlay
+        mask2 = np.zeros((64, 64), dtype=np.int32)
+        mask2[50:60, 50:60] = 1
+
+        rgb = mc.merge(
+            [arr1, arr2],
+            ['betterBlue', 'betterOrange'],
+            saturation_limits=[(0, 255), (0, 255)],
+            masks=[mask1, mask2],
+            mask_colors=['#FF0000', '#00FF00'],
+            boundaries_only=[True, False],  # First boundary-only, second full
+        )
+
+        assert rgb.shape == (64, 64, 3)
+        assert rgb.dtype == np.uint8
+
+        # Compare with full mask overlays to verify boundaries_only works
+        rgb_full = mc.merge(
+            [arr1, arr2],
+            ['betterBlue', 'betterOrange'],
+            saturation_limits=[(0, 255), (0, 255)],
+            masks=[mask1, mask2],
+            mask_colors=['#FF0000', '#00FF00'],
+            boundaries_only=[False, False],  # Both full overlays
+        )
+
+        # First mask interior: boundary-only should have LESS red than full
+        assert rgb_full[10, 10, 0] > rgb[10, 10, 0]  # Full has more red in interior
+
+        # First mask boundary should be the same
+        assert rgb[5, 10, 0] == rgb_full[5, 10, 0]  # Top edge same in both
+
+        # Second mask interior should be the same (both have full overlay for mask2)
+        assert rgb[55, 55, 1] == rgb_full[55, 55, 1]  # Center of second mask same
+
+    def test_boundaries_only_length_mismatch_raises(self):
+        """boundaries_only list with wrong length should raise ValueError."""
+        arr = np.zeros((64, 64), dtype=np.uint8)
+        mask1 = np.zeros((64, 64), dtype=np.bool_)
+        mask1[10:20, 10:20] = True
+        mask2 = np.zeros((64, 64), dtype=np.bool_)
+        mask2[30:40, 30:40] = True
+
+        with pytest.raises(ValueError, match='boundaries_only values .* does not match'):
+            mc.apply_color_map(
+                arr,
+                'Grays',
+                saturation_limits=(0, 255),
+                masks=[mask1, mask2],
+                boundaries_only=[True],  # Wrong length - should be 2
+            )
+
+    def test_boundaries_only_none_defaults_to_false(self):
+        """boundaries_only=None should default to False for all masks."""
+        arr = np.zeros((64, 64), dtype=np.uint8)
+        arr[20:44, 20:44] = 128
+
+        mask = np.zeros((64, 64), dtype=np.int32)
+        mask[30:50, 30:50] = 1
+
+        rgb = mc.apply_color_map(
+            arr,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask],
+            mask_colors=['#00FF00'],
+            boundaries_only=None,  # Should default to False
+        )
+
+        # Interior of mask should have green (full overlay, not boundary-only)
+        assert rgb[40, 40, 1] > 0  # Center should have green
+
+    def test_boundaries_only_all_false_same_as_none(self):
+        """boundaries_only=[False, False] should behave same as None."""
+        arr = np.zeros((64, 64), dtype=np.uint8)
+        arr[20:44, 20:44] = 128
+
+        mask1 = np.zeros((64, 64), dtype=np.bool_)
+        mask1[10:20, 10:20] = True
+        mask2 = np.zeros((64, 64), dtype=np.int32)
+        mask2[30:50, 30:50] = 1
+
+        rgb_none = mc.apply_color_map(
+            arr,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask1, mask2],
+            mask_colors=['#FF0000', '#00FF00'],
+            boundaries_only=None,
+        )
+
+        rgb_false = mc.apply_color_map(
+            arr,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask1, mask2],
+            mask_colors=['#FF0000', '#00FF00'],
+            boundaries_only=[False, False],
+        )
+
+        np.testing.assert_array_equal(rgb_none, rgb_false)

--- a/pytests/test_boundaries_only.py
+++ b/pytests/test_boundaries_only.py
@@ -1,0 +1,97 @@
+"""Tests for boundaries_only parameter in apply_color_map and merge."""
+
+import warnings
+
+import mergechannels as mc
+import numpy as np
+import pytest
+
+
+class TestBoundariesOnly3DWarning:
+    """Test that boundaries_only=True emits a warning for 3D arrays."""
+
+    def test_apply_color_map_3d_warning(self):
+        """apply_color_map should warn when boundaries_only=True with 3D array."""
+        arr = np.random.randint(0, 256, (5, 64, 64), dtype=np.uint8)
+        mask = np.zeros((5, 64, 64), dtype=np.bool_)
+        mask[:, 20:40, 20:40] = True
+
+        with pytest.warns(
+            UserWarning,
+            match='boundaries_only=True is not supported for 3D arrays',
+        ):
+            mc.apply_color_map(
+                arr,
+                'Grays',
+                saturation_limits=(0, 255),
+                masks=[mask],
+                boundaries_only=True,
+            )
+
+    def test_merge_3d_warning(self):
+        """merge should warn when boundaries_only=True with 3D arrays."""
+        arr1 = np.random.randint(0, 256, (5, 64, 64), dtype=np.uint8)
+        arr2 = np.random.randint(0, 256, (5, 64, 64), dtype=np.uint8)
+        mask = np.zeros((5, 64, 64), dtype=np.bool_)
+        mask[:, 20:40, 20:40] = True
+
+        with pytest.warns(
+            UserWarning,
+            match='boundaries_only=True is not supported for 3D arrays',
+        ):
+            mc.merge(
+                [arr1, arr2],
+                ['betterBlue', 'betterOrange'],
+                saturation_limits=[(0, 255), (0, 255)],
+                masks=[mask],
+                boundaries_only=True,
+            )
+
+    def test_apply_color_map_2d_no_warning(self):
+        """apply_color_map should NOT warn when boundaries_only=True with 2D array."""
+        arr = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+        mask = np.zeros((64, 64), dtype=np.bool_)
+        mask[20:40, 20:40] = True
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            # Should not raise any warnings
+            mc.apply_color_map(
+                arr,
+                'Grays',
+                saturation_limits=(0, 255),
+                masks=[mask],
+                boundaries_only=True,
+            )
+
+    def test_merge_2d_no_warning(self):
+        """merge should NOT warn when boundaries_only=True with 2D arrays."""
+        arr1 = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+        arr2 = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+        mask = np.zeros((64, 64), dtype=np.bool_)
+        mask[20:40, 20:40] = True
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            # Should not raise any warnings
+            mc.merge(
+                [arr1, arr2],
+                ['betterBlue', 'betterOrange'],
+                saturation_limits=[(0, 255), (0, 255)],
+                masks=[mask],
+                boundaries_only=True,
+            )
+
+    def test_no_warning_without_masks(self):
+        """No warning should be emitted if boundaries_only=True but no masks provided."""
+        arr = np.random.randint(0, 256, (5, 64, 64), dtype=np.uint8)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            # Should not raise any warnings since there are no masks
+            mc.apply_color_map(
+                arr,
+                'Grays',
+                saturation_limits=(0, 255),
+                boundaries_only=True,
+            )

--- a/pytests/test_create_mask_boundaries.py
+++ b/pytests/test_create_mask_boundaries.py
@@ -1,0 +1,439 @@
+"""Tests for create_mask_boundaries function.
+
+Tests verify boundary detection for:
+- Different data types (bool, int32, uint16)
+- Uniform regions (no boundaries)
+- Two adjacent regions (boundary at interface)
+- Multiple labels
+- Small arrays (edge cases)
+- Negative values (for int32)
+- Cross-dtype consistency
+"""
+
+import mergechannels as mc
+import numpy as np
+import pytest
+
+
+class TestUniformRegions:
+    """Test that uniform regions produce no boundaries."""
+
+    def test_uniform_bool(self):
+        """All True values should produce no boundaries."""
+        arr = np.ones((4, 4), dtype=bool)
+        result = mc.create_mask_boundaries(arr)
+        assert result.dtype == bool
+        assert result.shape == (4, 4)
+        assert not result.any()
+
+    def test_uniform_i32(self):
+        """All same int32 value should produce no boundaries."""
+        arr = np.full((4, 4), 5, dtype=np.int32)
+        result = mc.create_mask_boundaries(arr)
+        assert result.dtype == bool
+        assert result.shape == (4, 4)
+        assert not result.any()
+
+    def test_uniform_u16(self):
+        """All same uint16 value should produce no boundaries."""
+        arr = np.full((4, 4), 1000, dtype=np.uint16)
+        result = mc.create_mask_boundaries(arr)
+        assert result.dtype == bool
+        assert result.shape == (4, 4)
+        assert not result.any()
+
+    def test_uniform_u8(self):
+        """All same uint8 value should produce no boundaries."""
+        arr = np.full((4, 4), 100, dtype=np.uint8)
+        result = mc.create_mask_boundaries(arr)
+        assert result.dtype == bool
+        assert result.shape == (4, 4)
+        assert not result.any()
+
+
+class TestTwoRegions:
+    """Test boundary detection between two distinct regions."""
+
+    def test_two_regions_bool(self):
+        """Test bool array with two regions."""
+        arr = np.array(
+            [
+                [False, False, True, True],
+                [False, False, True, True],
+                [False, False, True, True],
+            ],
+            dtype=bool,
+        )
+        result = mc.create_mask_boundaries(arr)
+        expected = np.array(
+            [
+                [False, True, True, False],
+                [False, True, True, False],
+                [False, True, True, False],
+            ],
+            dtype=bool,
+        )
+        np.testing.assert_array_equal(result, expected)
+
+    def test_two_regions_i32(self):
+        """Test int32 array with two labeled regions."""
+        arr = np.array(
+            [
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+            ],
+            dtype=np.int32,
+        )
+        result = mc.create_mask_boundaries(arr)
+        expected = np.array(
+            [
+                [False, True, True, False],
+                [False, True, True, False],
+                [False, True, True, False],
+            ],
+            dtype=bool,
+        )
+        np.testing.assert_array_equal(result, expected)
+
+    def test_two_regions_u16(self):
+        """Test uint16 array with two regions."""
+        arr = np.array(
+            [
+                [100, 100, 200, 200],
+                [100, 100, 200, 200],
+                [100, 100, 200, 200],
+            ],
+            dtype=np.uint16,
+        )
+        result = mc.create_mask_boundaries(arr)
+        expected = np.array(
+            [
+                [False, True, True, False],
+                [False, True, True, False],
+                [False, True, True, False],
+            ],
+            dtype=bool,
+        )
+        np.testing.assert_array_equal(result, expected)
+
+    def test_two_regions_u8(self):
+        """Test uint8 array with two regions."""
+        arr = np.array(
+            [
+                [10, 10, 20, 20],
+                [10, 10, 20, 20],
+                [10, 10, 20, 20],
+            ],
+            dtype=np.uint8,
+        )
+        result = mc.create_mask_boundaries(arr)
+        expected = np.array(
+            [
+                [False, True, True, False],
+                [False, True, True, False],
+                [False, True, True, False],
+            ],
+            dtype=bool,
+        )
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestSingleDifferentPixel:
+    """Test that a single different pixel creates boundaries everywhere."""
+
+    def test_single_pixel_bool(self):
+        """Single True pixel in sea of False should make all pixels boundaries."""
+        arr = np.array(
+            [
+                [False, False, False],
+                [False, True, False],
+                [False, False, False],
+            ],
+            dtype=bool,
+        )
+        result = mc.create_mask_boundaries(arr)
+        # All pixels are boundaries because they all touch the different center pixel
+        assert result.all()
+
+    def test_single_pixel_i32(self):
+        """Single different label should make all pixels boundaries."""
+        arr = np.array(
+            [
+                [0, 0, 0],
+                [0, 1, 0],
+                [0, 0, 0],
+            ],
+            dtype=np.int32,
+        )
+        result = mc.create_mask_boundaries(arr)
+        assert result.all()
+
+    def test_single_pixel_u16(self):
+        """Single different value should make all pixels boundaries."""
+        arr = np.array(
+            [
+                [0, 0, 0],
+                [0, 1, 0],
+                [0, 0, 0],
+            ],
+            dtype=np.uint16,
+        )
+        result = mc.create_mask_boundaries(arr)
+        assert result.all()
+
+
+class TestSmallArrays:
+    """Test edge cases with small arrays."""
+
+    def test_1x1_uniform(self):
+        """1x1 array should have no boundary."""
+        arr = np.array([[5]], dtype=np.int32)
+        result = mc.create_mask_boundaries(arr)
+        assert result.shape == (1, 1)
+        assert not result[0, 0]
+
+    def test_2x2_uniform(self):
+        """2x2 uniform array should have no boundaries."""
+        arr = np.array([[1, 1], [1, 1]], dtype=np.int32)
+        result = mc.create_mask_boundaries(arr)
+        assert result.shape == (2, 2)
+        assert not result.any()
+
+    def test_2x2_mixed(self):
+        """2x2 mixed array should have all boundaries."""
+        arr = np.array([[1, 2], [1, 1]], dtype=np.int32)
+        result = mc.create_mask_boundaries(arr)
+        assert result.shape == (2, 2)
+        assert result.all()
+
+
+class TestMultipleLabels:
+    """Test arrays with multiple distinct labels."""
+
+    def test_three_labels_i32(self):
+        """Test with three adjacent labeled regions."""
+        arr = np.array(
+            [
+                [1, 1, 2, 2, 3, 3],
+                [1, 1, 2, 2, 3, 3],
+                [1, 1, 2, 2, 3, 3],
+            ],
+            dtype=np.int32,
+        )
+        result = mc.create_mask_boundaries(arr)
+        expected = np.array(
+            [
+                [False, True, True, True, True, False],
+                [False, True, True, True, True, False],
+                [False, True, True, True, True, False],
+            ],
+            dtype=bool,
+        )
+        np.testing.assert_array_equal(result, expected)
+
+    def test_checkerboard_pattern(self):
+        """Test checkerboard pattern creates dense boundaries."""
+        arr = np.array(
+            [
+                [0, 1, 0, 1],
+                [1, 0, 1, 0],
+                [0, 1, 0, 1],
+                [1, 0, 1, 0],
+            ],
+            dtype=np.int32,
+        )
+        result = mc.create_mask_boundaries(arr)
+        # In a checkerboard, every pixel should be a boundary
+        assert result.all()
+
+
+class TestNegativeValues:
+    """Test int32 arrays with negative label values."""
+
+    def test_negative_labels(self):
+        """Test that negative labels work correctly."""
+        arr = np.array(
+            [
+                [-1, -1, 0, 0],
+                [-1, -1, 0, 0],
+                [-1, -1, 0, 0],
+            ],
+            dtype=np.int32,
+        )
+        result = mc.create_mask_boundaries(arr)
+        expected = np.array(
+            [
+                [False, True, True, False],
+                [False, True, True, False],
+                [False, True, True, False],
+            ],
+            dtype=bool,
+        )
+        np.testing.assert_array_equal(result, expected)
+
+    def test_all_negative_uniform(self):
+        """Test uniform array with negative values has no boundaries."""
+        arr = np.full((3, 3), -5, dtype=np.int32)
+        result = mc.create_mask_boundaries(arr)
+        assert not result.any()
+
+
+class TestDtypeConsistency:
+    """Test that equivalent patterns produce consistent results across dtypes."""
+
+    def test_two_regions_consistency(self):
+        """Same pattern should produce identical results across dtypes."""
+
+        # Create equivalent patterns
+        arr_bool = np.array(
+            [
+                [False, False, True, True],
+                [False, False, True, True],
+                [False, False, True, True],
+            ],
+            dtype=bool,
+        )
+        arr_i32 = np.array(
+            [
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+            ],
+            dtype=np.int32,
+        )
+        arr_u16 = np.array(
+            [
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+            ],
+            dtype=np.uint16,
+        )
+        arr_u8 = np.array(
+            [
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+                [1, 1, 2, 2],
+            ],
+            dtype=np.uint8,
+        )
+
+        result_bool = mc.create_mask_boundaries(arr_bool)
+        result_i32 = mc.create_mask_boundaries(arr_i32)
+        result_u16 = mc.create_mask_boundaries(arr_u16)
+        result_u8 = mc.create_mask_boundaries(arr_u8)
+
+        # All should produce the same boundary pattern
+        np.testing.assert_array_equal(result_bool, result_i32)
+        np.testing.assert_array_equal(result_bool, result_u16)
+        np.testing.assert_array_equal(result_bool, result_u8)
+
+    def test_uniform_consistency(self):
+        """Uniform arrays should produce no boundaries regardless of dtype."""
+        arr_bool = np.ones((3, 3), dtype=bool)
+        arr_u8 = np.full((3, 3), 50, dtype=np.uint8)
+        arr_i32 = np.full((3, 3), 5, dtype=np.int32)
+        arr_u16 = np.full((3, 3), 100, dtype=np.uint16)
+
+        result_bool = mc.create_mask_boundaries(arr_bool)
+        result_u8 = mc.create_mask_boundaries(arr_u8)
+        result_i32 = mc.create_mask_boundaries(arr_i32)
+        result_u16 = mc.create_mask_boundaries(arr_u16)
+
+        assert not result_bool.any()
+        assert not result_u8.any()
+        assert not result_i32.any()
+        assert not result_u16.any()
+
+
+class TestEdgeCases:
+    """Test edge and corner pixel behavior."""
+
+    def test_edge_pixels_different(self):
+        """Test that edge pixels with different neighbors are detected."""
+        arr = np.array(
+            [
+                [1, 1, 1],
+                [1, 2, 1],
+                [1, 1, 1],
+            ],
+            dtype=np.int32,
+        )
+        result = mc.create_mask_boundaries(arr)
+        # All pixels should be boundaries
+        assert result.all()
+
+    def test_corner_difference(self):
+        """Test corner pixel with different value."""
+        arr = np.array(
+            [
+                [1, 0, 0],
+                [0, 0, 0],
+                [0, 0, 0],
+            ],
+            dtype=np.int32,
+        )
+        result = mc.create_mask_boundaries(arr)
+        # Pixels that touch the corner should be boundaries
+        assert result[0, 0]  # The different corner itself
+        assert result[0, 1]  # Right neighbor
+        assert result[1, 0]  # Bottom neighbor
+        assert result[1, 1]  # Diagonal neighbor
+
+
+class TestInvalidInputs:
+    """Test error handling for invalid inputs."""
+
+    def test_wrong_dtype_raises_error(self):
+        """Test that unsupported dtype raises error."""
+        arr = np.ones((3, 3), dtype=np.float32)
+        with pytest.raises(ValueError, match='only supports bool, uint8, int32, and uint16'):
+            mc.create_mask_boundaries(arr)
+
+    def test_3d_array_raises_error(self):
+        """Test that 3D array raises error."""
+        arr = np.ones((3, 3, 3), dtype=np.int32)
+        with pytest.raises(ValueError, match='unsupported number of dimensions'):
+            mc.create_mask_boundaries(arr)
+
+    def test_1d_array_raises_error(self):
+        """Test that 1D array raises error."""
+        arr = np.ones(10, dtype=np.int32)
+        with pytest.raises(ValueError, match='unsupported number of dimensions'):
+            mc.create_mask_boundaries(arr)
+
+
+class TestLargerArrays:
+    """Test with slightly larger arrays to ensure scalability."""
+
+    def test_50x50_uniform(self):
+        """Test that larger uniform array has no boundaries."""
+        arr = np.full((50, 50), 42, dtype=np.int32)
+        result = mc.create_mask_boundaries(arr)
+        assert result.shape == (50, 50)
+        assert not result.any()
+
+    def test_50x50_vertical_split(self):
+        """Test larger array with vertical boundary."""
+        arr = np.zeros((50, 50), dtype=np.int32)
+        arr[:, 25:] = 1
+        result = mc.create_mask_boundaries(arr)
+
+        # Only columns 24 and 25 should have boundaries
+        assert not result[:, :24].any()
+        assert result[:, 24].all()
+        assert result[:, 25].all()
+        assert not result[:, 26:].any()
+
+    def test_50x50_horizontal_split(self):
+        """Test larger array with horizontal boundary."""
+        arr = np.zeros((50, 50), dtype=np.int32)
+        arr[25:, :] = 1
+        result = mc.create_mask_boundaries(arr)
+
+        # Only rows 24 and 25 should have boundaries
+        assert not result[:24, :].any()
+        assert result[24, :].all()
+        assert result[25, :].all()
+        assert not result[26:, :].any()

--- a/pytests/test_mask_overlay.py
+++ b/pytests/test_mask_overlay.py
@@ -333,6 +333,132 @@ class TestMaskOverlayNamedColors:
         assert result[0, 1, 2] == blended[2]
 
 
+class TestMaskOverlayU8U16Masks:
+    """Test mask overlay with uint8 and uint16 mask dtypes."""
+
+    def test_u8_mask_overlay_2d(self, arr_u8):
+        """Test uint8 mask overlay on 2D array (non-zero values are active)."""
+        mask = np.array(
+            [
+                [0, 1, 0],
+                [2, 0, 255],
+                [0, 128, 0],
+            ],
+            dtype=np.uint8,
+        )
+
+        base_color = (100, 100, 100)
+        blended = alpha_blend(base_color, PURPLE, ALPHA)
+
+        result = mc.apply_color_map(
+            arr_u8,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask],
+            mask_colors=[PURPLE],
+            mask_alphas=[ALPHA],
+        )
+
+        # Pixels where mask == 0 should be unchanged
+        assert result[0, 0, 0] == base_color[0]
+        assert result[1, 1, 0] == base_color[0]
+        assert result[2, 0, 0] == base_color[0]
+
+        # Pixels where mask != 0 should be blended
+        assert result[0, 1, 0] == blended[0]  # mask = 1
+        assert result[1, 0, 0] == blended[0]  # mask = 2
+        assert result[1, 2, 0] == blended[0]  # mask = 255
+        assert result[2, 1, 0] == blended[0]  # mask = 128
+
+    def test_u16_mask_overlay_2d(self, arr_u8):
+        """Test uint16 mask overlay on 2D array (non-zero values are active)."""
+        mask = np.array(
+            [
+                [0, 1, 0],
+                [2, 0, 65535],
+                [0, 32768, 0],
+            ],
+            dtype=np.uint16,
+        )
+
+        base_color = (100, 100, 100)
+        blended = alpha_blend(base_color, PURPLE, ALPHA)
+
+        result = mc.apply_color_map(
+            arr_u8,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask],
+            mask_colors=[PURPLE],
+            mask_alphas=[ALPHA],
+        )
+
+        # Pixels where mask == 0 should be unchanged
+        assert result[0, 0, 0] == base_color[0]
+        assert result[1, 1, 0] == base_color[0]
+        assert result[2, 0, 0] == base_color[0]
+
+        # Pixels where mask != 0 should be blended
+        assert result[0, 1, 0] == blended[0]  # mask = 1
+        assert result[1, 0, 0] == blended[0]  # mask = 2
+        assert result[1, 2, 0] == blended[0]  # mask = 65535
+        assert result[2, 1, 0] == blended[0]  # mask = 32768
+
+    def test_u8_mask_overlay_3d(self):
+        """Test uint8 mask overlay on 3D array."""
+        arr_3d = np.full((2, 3, 3), 100, dtype=np.uint8)
+        mask = np.zeros((2, 3, 3), dtype=np.uint8)
+        mask[0, 1, 1] = 1
+        mask[1, 0, 0] = 255
+
+        base_color = (100, 100, 100)
+        blended = alpha_blend(base_color, PURPLE, ALPHA)
+
+        result = mc.apply_color_map(
+            arr_3d,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask],
+            mask_colors=[PURPLE],
+            mask_alphas=[ALPHA],
+        )
+
+        # Pixels where mask == 0 should be unchanged
+        assert result[0, 0, 0, 0] == base_color[0]
+        assert result[1, 1, 1, 0] == base_color[0]
+
+        # Pixels where mask != 0 should be blended
+        assert result[0, 1, 1, 0] == blended[0]  # mask = 1
+        assert result[1, 0, 0, 0] == blended[0]  # mask = 255
+
+    def test_u16_mask_overlay_3d(self):
+        """Test uint16 mask overlay on 3D array."""
+        arr_3d = np.full((2, 3, 3), 100, dtype=np.uint8)
+        mask = np.zeros((2, 3, 3), dtype=np.uint16)
+        mask[0, 1, 1] = 1
+        mask[1, 0, 0] = 65535
+
+        base_color = (100, 100, 100)
+        blended = alpha_blend(base_color, PURPLE, ALPHA)
+
+        result = mc.apply_color_map(
+            arr_3d,
+            'Grays',
+            saturation_limits=(0, 255),
+            masks=[mask],
+            mask_colors=[PURPLE],
+            mask_alphas=[ALPHA],
+        )
+
+        # Pixels where mask == 0 should be unchanged
+        assert result[0, 0, 0, 0] == base_color[0]
+        assert result[1, 1, 1, 0] == base_color[0]
+
+        # Pixels where mask != 0 should be blended
+        assert result[0, 1, 1, 0] == blended[0]  # mask = 1
+        assert result[1, 0, 0, 0] == blended[0]  # mask = 65535
+
+
 class TestMaskOverlayMultipleMasks:
     """Test mask overlay with multiple masks."""
 

--- a/python/mergechannels/__init__.py
+++ b/python/mergechannels/__init__.py
@@ -6,6 +6,7 @@ from ._internal import (
 )
 from ._luts import COLORMAPS
 from .mergechannels import (
+    create_mask_boundaries,
     dispatch_multi_channel,
     dispatch_single_channel,
 )
@@ -17,5 +18,6 @@ __all__ = [
     'apply_color_map',
     'get_cmap_array',
     'get_mpl_cmap',
+    'create_mask_boundaries',
     'COLORMAPS',
 ]

--- a/python/mergechannels/_internal.py
+++ b/python/mergechannels/_internal.py
@@ -12,6 +12,9 @@ import numpy as np
 
 from ._blending import BLENDING_OPTIONS
 from ._luts import COLORMAPS
+from .mergechannels import (
+    create_mask_boundaries as _create_mask_boundaries,  # aliasing to inject docstring and types
+)
 from .mergechannels import (  # type: ignore
     dispatch_multi_channel,
     dispatch_single_channel,
@@ -598,3 +601,25 @@ def get_mpl_cmap(name: COLORMAPS) -> ListedColormap:
     cmap_array = get_cmap_array(name)
     colors = cmap_array / 255.0  # Convert from uint8 (0-255) to float (0-1) for matplotlib
     return ListedColormap(colors, name=name)
+
+
+def create_mask_boundaries(arr: np.ndarray):
+    """
+    Create a boolean mask defining the boundaries of the input masks
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input array of shape (H, W) with dtype bool, uint8, uint16, or i32.
+
+    Returns
+    -------
+    np.ndarray
+        a boolean array of shape (H, W) where boundaries of the input masks are True
+
+    Raises
+    ------
+    TypeError
+        If masks are not numpy arrays.
+    """
+    return _create_mask_boundaries(arr)

--- a/python/mergechannels/_internal.py
+++ b/python/mergechannels/_internal.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     )
 
 # Type alias for mask color specification
-MaskColor = Union[COLORMAPS, Tuple[int, int, int], Sequence[int]]
+MaskColor = Union[COLORMAPS, Tuple[int, int, int], Sequence[int], str]
 
 # Default mask color (purple) and alpha
 DEFAULT_MASK_COLOR: Tuple[int, int, int] = (128, 0, 128)

--- a/python/mergechannels/_internal.py
+++ b/python/mergechannels/_internal.py
@@ -612,7 +612,11 @@ def merge(
 
     # Parse mask arguments
     masks_list, colors_list, alphas_list, boundaries_list = _parse_mask_arguments(
-        masks, mask_colors, mask_alphas, boundaries_only, expected_shape=expected_shape
+        masks,
+        mask_colors,
+        mask_alphas,
+        boundaries_only,
+        expected_shape=expected_shape,
     )
 
     # Handle boundaries_only warning for 3D arrays

--- a/python/mergechannels/_internal.py
+++ b/python/mergechannels/_internal.py
@@ -468,7 +468,14 @@ def apply_color_map(
 
 def merge(
     arrs: Sequence[np.ndarray],
-    colors: Sequence[COLORMAPS],
+    colors: Sequence[
+        Union[
+            COLORMAPS,
+            NDArray[Shape['256, 3'], UInt8],
+            MatplotlibColormap,
+            CmapColormap,
+        ]
+    ],
     blending: BLENDING_OPTIONS = 'max',
     percentiles: Sequence[tuple[float, float]] | None = None,
     saturation_limits: Sequence[tuple[float, float]] | None = None,

--- a/src/colorize.rs
+++ b/src/colorize.rs
@@ -32,18 +32,22 @@ pub struct MaskConfig<A> {
     pub alpha: f32,     // Alpha value for blending (0.0-1.0)
 }
 
-/// Enum to hold either bool or i32 mask types for 2D arrays
+/// Enum to hold bool, i32, u8, or u16 mask types for 2D arrays
 #[allow(dead_code)] // Variants constructed via Python interface
 pub enum MaskConfig2D<'a> {
     Bool(MaskConfig<ArrayView2<'a, bool>>),
     I32(MaskConfig<ArrayView2<'a, i32>>),
+    U8(MaskConfig<ArrayView2<'a, u8>>),
+    U16(MaskConfig<ArrayView2<'a, u16>>),
 }
 
-/// Enum to hold either bool or i32 mask types for 3D arrays
+/// Enum to hold bool, i32, u8, or u16 mask types for 3D arrays
 #[allow(dead_code)] // Variants constructed via Python interface
 pub enum MaskConfig3D<'a> {
     Bool(MaskConfig<ArrayView3<'a, bool>>),
     I32(MaskConfig<ArrayView3<'a, i32>>),
+    U8(MaskConfig<ArrayView3<'a, u8>>),
+    U16(MaskConfig<ArrayView3<'a, u16>>),
 }
 
 impl<'a> MaskConfig2D<'a> {
@@ -52,6 +56,8 @@ impl<'a> MaskConfig2D<'a> {
         match self {
             MaskConfig2D::Bool(m) => m.arr[[i, j]],
             MaskConfig2D::I32(m) => m.arr[[i, j]] != 0,
+            MaskConfig2D::U8(m) => m.arr[[i, j]] != 0,
+            MaskConfig2D::U16(m) => m.arr[[i, j]] != 0,
         }
     }
 
@@ -60,6 +66,8 @@ impl<'a> MaskConfig2D<'a> {
         match self {
             MaskConfig2D::Bool(m) => m.color,
             MaskConfig2D::I32(m) => m.color,
+            MaskConfig2D::U8(m) => m.color,
+            MaskConfig2D::U16(m) => m.color,
         }
     }
 
@@ -68,6 +76,8 @@ impl<'a> MaskConfig2D<'a> {
         match self {
             MaskConfig2D::Bool(m) => m.alpha,
             MaskConfig2D::I32(m) => m.alpha,
+            MaskConfig2D::U8(m) => m.alpha,
+            MaskConfig2D::U16(m) => m.alpha,
         }
     }
 }
@@ -78,6 +88,8 @@ impl<'a> MaskConfig3D<'a> {
         match self {
             MaskConfig3D::Bool(m) => m.arr[[n, i, j]],
             MaskConfig3D::I32(m) => m.arr[[n, i, j]] != 0,
+            MaskConfig3D::U8(m) => m.arr[[n, i, j]] != 0,
+            MaskConfig3D::U16(m) => m.arr[[n, i, j]] != 0,
         }
     }
 
@@ -86,6 +98,8 @@ impl<'a> MaskConfig3D<'a> {
         match self {
             MaskConfig3D::Bool(m) => m.color,
             MaskConfig3D::I32(m) => m.color,
+            MaskConfig3D::U8(m) => m.color,
+            MaskConfig3D::U16(m) => m.color,
         }
     }
 
@@ -94,6 +108,8 @@ impl<'a> MaskConfig3D<'a> {
         match self {
             MaskConfig3D::Bool(m) => m.alpha,
             MaskConfig3D::I32(m) => m.alpha,
+            MaskConfig3D::U8(m) => m.alpha,
+            MaskConfig3D::U16(m) => m.alpha,
         }
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -3,6 +3,9 @@ use crate::colorize;
 use crate::errors;
 use crate::process;
 use ndarray::Array2;
+
+/// Mask metadata: RGB color and alpha value
+type MaskMetadata = ([u8; 3], f32);
 use numpy::{
     IntoPyArray, PyArray2, PyArrayDyn, PyReadonlyArray2, PyReadonlyArray3, PyUntypedArray,
     PyUntypedArrayMethods,
@@ -169,7 +172,7 @@ impl<'py> ExtractedMasks2D<'py> {
     /// Compute boundary detection on each mask and return owned boundary arrays.
     /// Returns a tuple of (boundary_arrays, mask_metadata) where mask_metadata contains
     /// (color, alpha) for each mask in the same order.
-    fn compute_boundaries(&self) -> (Vec<Array2<bool>>, Vec<([u8; 3], f32)>) {
+    fn compute_boundaries(&self) -> (Vec<Array2<bool>>, Vec<MaskMetadata>) {
         let mut boundaries = Vec::with_capacity(self.mask_info.len());
         let mut metadata = Vec::with_capacity(self.mask_info.len());
 
@@ -192,7 +195,7 @@ impl<'py> ExtractedMasks2D<'py> {
 /// The boundary_arrays must outlive the returned Vec
 fn build_masks_from_boundaries<'a>(
     boundary_arrays: &'a [Array2<bool>],
-    metadata: &[([u8; 3], f32)],
+    metadata: &[MaskMetadata],
 ) -> Vec<colorize::MaskConfig2D<'a>> {
     boundary_arrays
         .iter()

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -565,7 +565,7 @@ pub fn dispatch_multi_channel_py<'py>(
 /// This is equivalent to: max_filter(arr, 3, 'reflect') != min_filter(arr, 3, 'reflect')
 /// but computed in a single pass without intermediate arrays.
 ///
-/// Supports bool and uint16 input arrays.
+/// Supports bool, uint8, int32, and uint16 input arrays.
 /// Returns a boolean array where True indicates a boundary pixel.
 #[pyfunction]
 #[pyo3(name = "create_mask_boundaries")]
@@ -586,6 +586,10 @@ pub fn create_mask_boundaries_py<'py>(
             let py_arr = array_reference.extract::<PyReadonlyArray2<bool>>()?;
             Ok(process::find_boundaries(py_arr.as_array()).into_pyarray(py))
         }
+        "uint8" => {
+            let py_arr = array_reference.extract::<PyReadonlyArray2<u8>>()?;
+            Ok(process::find_boundaries(py_arr.as_array()).into_pyarray(py))
+        }
         "int32" => {
             let py_arr = array_reference.extract::<PyReadonlyArray2<i32>>()?;
             Ok(process::find_boundaries(py_arr.as_array()).into_pyarray(py))
@@ -595,7 +599,7 @@ pub fn create_mask_boundaries_py<'py>(
             Ok(process::find_boundaries(py_arr.as_array()).into_pyarray(py))
         }
         _ => Err(PyValueError::new_err(format!(
-            "create_mask_boundaries only supports bool, int32, and uint16 arrays, got dtype '{}'",
+            "create_mask_boundaries only supports bool, uint8, int32, and uint16 arrays, got dtype '{}'",
             dtype
         ))),
     }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -584,21 +584,15 @@ pub fn create_mask_boundaries_py<'py>(
     match dtype.as_str() {
         "bool" => {
             let py_arr = array_reference.extract::<PyReadonlyArray2<bool>>()?;
-            let arr = py_arr.as_array();
-            let result = process::find_boundaries_bool(arr);
-            Ok(result.into_pyarray(py))
+            Ok(process::find_boundaries(py_arr.as_array()).into_pyarray(py))
         }
         "int32" => {
             let py_arr = array_reference.extract::<PyReadonlyArray2<i32>>()?;
-            let arr = py_arr.as_array();
-            let result = process::find_boundaries_i32(arr);
-            Ok(result.into_pyarray(py))
+            Ok(process::find_boundaries(py_arr.as_array()).into_pyarray(py))
         }
         "uint16" => {
             let py_arr = array_reference.extract::<PyReadonlyArray2<u16>>()?;
-            let arr = py_arr.as_array();
-            let result = process::find_boundaries_u16(arr);
-            Ok(result.into_pyarray(py))
+            Ok(process::find_boundaries(py_arr.as_array()).into_pyarray(py))
         }
         _ => Err(PyValueError::new_err(format!(
             "create_mask_boundaries only supports bool, int32, and uint16 arrays, got dtype '{}'",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,12 @@ mod cmaps;
 mod colorize;
 mod errors;
 mod interface;
+mod process;
 
-use interface::{dispatch_multi_channel_py, dispatch_single_channel_py, get_cmap_array_py};
+use interface::{
+    create_mask_boundaries_py, dispatch_multi_channel_py, dispatch_single_channel_py,
+    get_cmap_array_py,
+};
 use pyo3::prelude::*;
 
 /// This module is thread-safe and supports free-threaded Python (Python 3.13+ without GIL).
@@ -18,5 +22,6 @@ fn mergechannels(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(dispatch_single_channel_py, m)?)?;
     m.add_function(wrap_pyfunction!(dispatch_multi_channel_py, m)?)?;
     m.add_function(wrap_pyfunction!(get_cmap_array_py, m)?)?;
+    m.add_function(wrap_pyfunction!(create_mask_boundaries_py, m)?)?;
     Ok(())
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,553 @@
+use ndarray::{Array2, ArrayView2};
+
+/// Check if a 3x3 window has non-uniform values using direct slice access.
+/// This is the fast path for interior pixels where no bounds checking is needed.
+#[inline(always)]
+fn is_boundary_interior_u16(arr: &ArrayView2<u16>, y: usize, x: usize) -> bool {
+    // SAFETY: Caller guarantees y in [1, h-2] and x in [1, w-2]
+    unsafe {
+        let first = *arr.uget((y - 1, x - 1));
+
+        // Check all 9 positions, early exit on difference
+        // Row y-1
+        if *arr.uget((y - 1, x)) != first {
+            return true;
+        }
+        if *arr.uget((y - 1, x + 1)) != first {
+            return true;
+        }
+        // Row y
+        if *arr.uget((y, x - 1)) != first {
+            return true;
+        }
+        if *arr.uget((y, x)) != first {
+            return true;
+        }
+        if *arr.uget((y, x + 1)) != first {
+            return true;
+        }
+        // Row y+1
+        if *arr.uget((y + 1, x - 1)) != first {
+            return true;
+        }
+        if *arr.uget((y + 1, x)) != first {
+            return true;
+        }
+        if *arr.uget((y + 1, x + 1)) != first {
+            return true;
+        }
+        false
+    }
+}
+
+/// Check if a 3x3 window has non-uniform values using direct slice access.
+/// This is the fast path for interior pixels where no bounds checking is needed.
+#[inline(always)]
+fn is_boundary_interior_i32(arr: &ArrayView2<i32>, y: usize, x: usize) -> bool {
+    // SAFETY: Caller guarantees y in [1, h-2] and x in [1, w-2]
+    unsafe {
+        let first = *arr.uget((y - 1, x - 1));
+
+        // Check all 9 positions, early exit on difference
+        // Row y-1
+        if *arr.uget((y - 1, x)) != first {
+            return true;
+        }
+        if *arr.uget((y - 1, x + 1)) != first {
+            return true;
+        }
+        // Row y
+        if *arr.uget((y, x - 1)) != first {
+            return true;
+        }
+        if *arr.uget((y, x)) != first {
+            return true;
+        }
+        if *arr.uget((y, x + 1)) != first {
+            return true;
+        }
+        // Row y+1
+        if *arr.uget((y + 1, x - 1)) != first {
+            return true;
+        }
+        if *arr.uget((y + 1, x)) != first {
+            return true;
+        }
+        if *arr.uget((y + 1, x + 1)) != first {
+            return true;
+        }
+        false
+    }
+}
+
+/// Check if a 3x3 window has non-uniform values using direct slice access.
+/// This is the fast path for interior pixels where no bounds checking is needed.
+#[inline(always)]
+fn is_boundary_interior_bool(arr: &ArrayView2<bool>, y: usize, x: usize) -> bool {
+    // SAFETY: Caller guarantees y in [1, h-2] and x in [1, w-2]
+    unsafe {
+        let first = *arr.uget((y - 1, x - 1));
+
+        // Check all 9 positions, early exit on difference
+        // Row y-1
+        if *arr.uget((y - 1, x)) != first {
+            return true;
+        }
+        if *arr.uget((y - 1, x + 1)) != first {
+            return true;
+        }
+        // Row y
+        if *arr.uget((y, x - 1)) != first {
+            return true;
+        }
+        if *arr.uget((y, x)) != first {
+            return true;
+        }
+        if *arr.uget((y, x + 1)) != first {
+            return true;
+        }
+        // Row y+1
+        if *arr.uget((y + 1, x - 1)) != first {
+            return true;
+        }
+        if *arr.uget((y + 1, x)) != first {
+            return true;
+        }
+        if *arr.uget((y + 1, x + 1)) != first {
+            return true;
+        }
+        false
+    }
+}
+
+/// Check if an edge pixel has any neighbor with a different value.
+/// Only visits valid in-bounds neighbors (no reflection/padding).
+#[inline]
+fn is_boundary_edge_u16(arr: &ArrayView2<u16>, cy: usize, cx: usize, h: usize, w: usize) -> bool {
+    let first = arr[[cy, cx]];
+    let y_start = cy.saturating_sub(1);
+    let y_end = (cy + 1).min(h - 1);
+    let x_start = cx.saturating_sub(1);
+    let x_end = (cx + 1).min(w - 1);
+
+    for y in y_start..=y_end {
+        for x in x_start..=x_end {
+            if arr[[y, x]] != first {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Check if an edge pixel has any neighbor with a different value.
+/// Only visits valid in-bounds neighbors (no reflection/padding).
+#[inline]
+fn is_boundary_edge_i32(arr: &ArrayView2<i32>, cy: usize, cx: usize, h: usize, w: usize) -> bool {
+    let first = arr[[cy, cx]];
+    let y_start = cy.saturating_sub(1);
+    let y_end = (cy + 1).min(h - 1);
+    let x_start = cx.saturating_sub(1);
+    let x_end = (cx + 1).min(w - 1);
+
+    for y in y_start..=y_end {
+        for x in x_start..=x_end {
+            if arr[[y, x]] != first {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Check if an edge pixel has any neighbor with a different value.
+/// Only visits valid in-bounds neighbors (no reflection/padding).
+#[inline]
+fn is_boundary_edge_bool(arr: &ArrayView2<bool>, cy: usize, cx: usize, h: usize, w: usize) -> bool {
+    let first = arr[[cy, cx]];
+    let y_start = cy.saturating_sub(1);
+    let y_end = (cy + 1).min(h - 1);
+    let x_start = cx.saturating_sub(1);
+    let x_end = (cx + 1).min(w - 1);
+
+    for y in y_start..=y_end {
+        for x in x_start..=x_end {
+            if arr[[y, x]] != first {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Detect boundary pixels where not all neighbors have the same value.
+/// This is equivalent to: max_filter(arr, 3, 'reflect') != min_filter(arr, 3, 'reflect')
+/// but computed in a single pass without intermediate arrays.
+///
+/// A pixel is considered a boundary if any value in its 3x3 neighborhood differs
+/// from the others (i.e., min != max in the neighborhood).
+///
+/// # Arguments
+/// * `arr` - 2D array view of u16 values (typically a label or thresholded image)
+///
+/// # Returns
+/// * `Array2<bool>` - Boolean array where true indicates a boundary pixel
+pub fn find_boundaries_u16(arr: ArrayView2<u16>) -> Array2<bool> {
+    let (height, width) = arr.dim();
+    let mut result = Array2::<bool>::from_elem((height, width), false);
+
+    // Handle degenerate cases
+    if height < 3 || width < 3 {
+        // All pixels are edge pixels, use slow path
+        for y in 0..height {
+            for x in 0..width {
+                result[[y, x]] = is_boundary_edge_u16(&arr, y, x, height, width);
+            }
+        }
+        return result;
+    }
+
+    // Process top edge (y = 0)
+    for x in 0..width {
+        result[[0, x]] = is_boundary_edge_u16(&arr, 0, x, height, width);
+    }
+
+    // Process bottom edge (y = height - 1)
+    for x in 0..width {
+        result[[height - 1, x]] = is_boundary_edge_u16(&arr, height - 1, x, height, width);
+    }
+
+    // Process left and right edges (y = 1..height-1)
+    for y in 1..height - 1 {
+        result[[y, 0]] = is_boundary_edge_u16(&arr, y, 0, height, width);
+        result[[y, width - 1]] = is_boundary_edge_u16(&arr, y, width - 1, height, width);
+    }
+
+    // Process interior (fast path - no bounds checking needed)
+    for y in 1..height - 1 {
+        for x in 1..width - 1 {
+            result[[y, x]] = is_boundary_interior_u16(&arr, y, x);
+        }
+    }
+
+    result
+}
+
+/// Detect boundary pixels where not all neighbors have the same value.
+/// This is equivalent to: max_filter(arr, 3, 'reflect') != min_filter(arr, 3, 'reflect')
+/// but computed in a single pass without intermediate arrays.
+///
+/// A pixel is considered a boundary if any value in its 3x3 neighborhood differs
+/// from the others (i.e., min != max in the neighborhood).
+///
+/// # Arguments
+/// * `arr` - 2D array view of i32 values (typically a label image)
+///
+/// # Returns
+/// * `Array2<bool>` - Boolean array where true indicates a boundary pixel
+pub fn find_boundaries_i32(arr: ArrayView2<i32>) -> Array2<bool> {
+    let (height, width) = arr.dim();
+    let mut result = Array2::<bool>::from_elem((height, width), false);
+
+    // Handle degenerate cases
+    if height < 3 || width < 3 {
+        // All pixels are edge pixels, use slow path
+        for y in 0..height {
+            for x in 0..width {
+                result[[y, x]] = is_boundary_edge_i32(&arr, y, x, height, width);
+            }
+        }
+        return result;
+    }
+
+    // Process top edge (y = 0)
+    for x in 0..width {
+        result[[0, x]] = is_boundary_edge_i32(&arr, 0, x, height, width);
+    }
+
+    // Process bottom edge (y = height - 1)
+    for x in 0..width {
+        result[[height - 1, x]] = is_boundary_edge_i32(&arr, height - 1, x, height, width);
+    }
+
+    // Process left and right edges (y = 1..height-1)
+    for y in 1..height - 1 {
+        result[[y, 0]] = is_boundary_edge_i32(&arr, y, 0, height, width);
+        result[[y, width - 1]] = is_boundary_edge_i32(&arr, y, width - 1, height, width);
+    }
+
+    // Process interior (fast path - no bounds checking needed)
+    for y in 1..height - 1 {
+        for x in 1..width - 1 {
+            result[[y, x]] = is_boundary_interior_i32(&arr, y, x);
+        }
+    }
+
+    result
+}
+
+/// Detect boundary pixels where not all neighbors have the same value.
+/// This is equivalent to: max_filter(arr, 3, 'reflect') != min_filter(arr, 3, 'reflect')
+/// but computed in a single pass without intermediate arrays.
+///
+/// A pixel is considered a boundary if any value in its 3x3 neighborhood differs
+/// from the others (i.e., min != max in the neighborhood).
+///
+/// # Arguments
+/// * `arr` - 2D array view of bool values (typically a binary mask)
+///
+/// # Returns
+/// * `Array2<bool>` - Boolean array where true indicates a boundary pixel
+pub fn find_boundaries_bool(arr: ArrayView2<bool>) -> Array2<bool> {
+    let (height, width) = arr.dim();
+    let mut result = Array2::<bool>::from_elem((height, width), false);
+
+    // Handle degenerate cases
+    if height < 3 || width < 3 {
+        // All pixels are edge pixels, use slow path
+        for y in 0..height {
+            for x in 0..width {
+                result[[y, x]] = is_boundary_edge_bool(&arr, y, x, height, width);
+            }
+        }
+        return result;
+    }
+
+    // Process top edge (y = 0)
+    for x in 0..width {
+        result[[0, x]] = is_boundary_edge_bool(&arr, 0, x, height, width);
+    }
+
+    // Process bottom edge (y = height - 1)
+    for x in 0..width {
+        result[[height - 1, x]] = is_boundary_edge_bool(&arr, height - 1, x, height, width);
+    }
+
+    // Process left and right edges (y = 1..height-1)
+    for y in 1..height - 1 {
+        result[[y, 0]] = is_boundary_edge_bool(&arr, y, 0, height, width);
+        result[[y, width - 1]] = is_boundary_edge_bool(&arr, y, width - 1, height, width);
+    }
+
+    // Process interior (fast path - no bounds checking needed)
+    for y in 1..height - 1 {
+        for x in 1..width - 1 {
+            result[[y, x]] = is_boundary_interior_bool(&arr, y, x);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_uniform_region_no_boundaries() {
+        // All same value - no boundaries in interior
+        let arr = array![[1u16, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1],];
+        let result = find_boundaries_u16(arr.view());
+        // All should be false - uniform region
+        assert!(result.iter().all(|&v| !v));
+    }
+
+    #[test]
+    fn test_single_different_pixel() {
+        // Single different pixel in center
+        let arr = array![[0u16, 0, 0], [0, 1, 0], [0, 0, 0],];
+        let result = find_boundaries_u16(arr.view());
+        // All pixels should be boundaries (all touch the different center pixel)
+        assert!(result.iter().all(|&v| v));
+    }
+
+    #[test]
+    fn test_two_regions() {
+        // Two distinct regions
+        let arr = array![[1u16, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
+        let result = find_boundaries_u16(arr.view());
+        // Expected: boundaries at columns 1 and 2 (adjacent to the edge)
+        let expected = array![
+            [false, true, true, false],
+            [false, true, true, false],
+            [false, true, true, false],
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_bool_boundaries() {
+        let arr = array![
+            [false, false, true, true],
+            [false, false, true, true],
+            [false, false, true, true],
+        ];
+        let result = find_boundaries_bool(arr.view());
+        let expected = array![
+            [false, true, true, false],
+            [false, true, true, false],
+            [false, true, true, false],
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_small_arrays_u16() {
+        // 1x1 uniform - no boundary
+        let arr = array![[5u16]];
+        let result = find_boundaries_u16(arr.view());
+        assert!(!result[[0, 0]]);
+
+        // 2x2 uniform - no boundaries
+        let arr = array![[1u16, 1], [1, 1]];
+        let result = find_boundaries_u16(arr.view());
+        assert!(result.iter().all(|&v| !v));
+
+        // 2x2 mixed - all boundaries
+        let arr = array![[1u16, 2], [1, 1]];
+        let result = find_boundaries_u16(arr.view());
+        assert!(result.iter().all(|&v| v));
+    }
+
+    // ===================
+    // i32 tests
+    // ===================
+
+    #[test]
+    fn test_i32_uniform_region_no_boundaries() {
+        // All same value - no boundaries
+        let arr = array![[1i32, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1],];
+        let result = find_boundaries_i32(arr.view());
+        assert!(result.iter().all(|&v| !v));
+    }
+
+    #[test]
+    fn test_i32_single_different_pixel() {
+        // Single different pixel in center - all pixels are boundaries
+        let arr = array![[0i32, 0, 0], [0, 1, 0], [0, 0, 0],];
+        let result = find_boundaries_i32(arr.view());
+        assert!(result.iter().all(|&v| v));
+    }
+
+    #[test]
+    fn test_i32_two_regions() {
+        // Two distinct regions side by side
+        let arr = array![[1i32, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
+        let result = find_boundaries_i32(arr.view());
+        let expected = array![
+            [false, true, true, false],
+            [false, true, true, false],
+            [false, true, true, false],
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_i32_negative_values() {
+        // Test with negative label values (common in some labeling schemes)
+        let arr = array![[-1i32, -1, 0, 0], [-1, -1, 0, 0], [-1, -1, 0, 0],];
+        let result = find_boundaries_i32(arr.view());
+        let expected = array![
+            [false, true, true, false],
+            [false, true, true, false],
+            [false, true, true, false],
+        ];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_i32_small_arrays() {
+        // 1x1 - no boundary
+        let arr = array![[5i32]];
+        let result = find_boundaries_i32(arr.view());
+        assert!(!result[[0, 0]]);
+
+        // 2x2 uniform - no boundaries
+        let arr = array![[1i32, 1], [1, 1]];
+        let result = find_boundaries_i32(arr.view());
+        assert!(result.iter().all(|&v| !v));
+
+        // 2x2 mixed - all boundaries
+        let arr = array![[1i32, 2], [1, 1]];
+        let result = find_boundaries_i32(arr.view());
+        assert!(result.iter().all(|&v| v));
+    }
+
+    #[test]
+    fn test_i32_multiple_labels() {
+        // Multiple distinct labels (typical segmentation mask)
+        let arr = array![
+            [1i32, 1, 2, 2, 3, 3],
+            [1, 1, 2, 2, 3, 3],
+            [1, 1, 2, 2, 3, 3],
+        ];
+        let result = find_boundaries_i32(arr.view());
+        // Boundaries at label transitions: cols 1-2 and 3-4
+        let expected = array![
+            [false, true, true, true, true, false],
+            [false, true, true, true, true, false],
+            [false, true, true, true, true, false],
+        ];
+        assert_eq!(result, expected);
+    }
+
+    // ===================
+    // Cross-dtype consistency tests
+    // ===================
+
+    #[test]
+    fn test_dtype_consistency_two_regions() {
+        // Same pattern should produce same results across dtypes
+        let arr_u16 = array![[1u16, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
+        let arr_i32 = array![[1i32, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
+        let arr_bool = array![
+            [false, false, true, true],
+            [false, false, true, true],
+            [false, false, true, true],
+        ];
+
+        let result_u16 = find_boundaries_u16(arr_u16.view());
+        let result_i32 = find_boundaries_i32(arr_i32.view());
+        let result_bool = find_boundaries_bool(arr_bool.view());
+
+        assert_eq!(result_u16, result_i32);
+        assert_eq!(result_u16, result_bool);
+    }
+
+    #[test]
+    fn test_dtype_consistency_uniform() {
+        // Uniform arrays should all produce no boundaries
+        let arr_u16 = array![[5u16, 5, 5], [5, 5, 5], [5, 5, 5],];
+        let arr_i32 = array![[5i32, 5, 5], [5, 5, 5], [5, 5, 5],];
+        let arr_bool = array![[true, true, true], [true, true, true], [true, true, true],];
+
+        let result_u16 = find_boundaries_u16(arr_u16.view());
+        let result_i32 = find_boundaries_i32(arr_i32.view());
+        let result_bool = find_boundaries_bool(arr_bool.view());
+
+        assert!(result_u16.iter().all(|&v| !v));
+        assert!(result_i32.iter().all(|&v| !v));
+        assert!(result_bool.iter().all(|&v| !v));
+    }
+
+    #[test]
+    fn test_dtype_consistency_center_pixel() {
+        // Single different center pixel - all should be boundaries
+        let arr_u16 = array![[0u16, 0, 0], [0, 1, 0], [0, 0, 0],];
+        let arr_i32 = array![[0i32, 0, 0], [0, 1, 0], [0, 0, 0],];
+        let arr_bool = array![
+            [false, false, false],
+            [false, true, false],
+            [false, false, false],
+        ];
+
+        let result_u16 = find_boundaries_u16(arr_u16.view());
+        let result_i32 = find_boundaries_i32(arr_i32.view());
+        let result_bool = find_boundaries_bool(arr_bool.view());
+
+        assert!(result_u16.iter().all(|&v| v));
+        assert!(result_i32.iter().all(|&v| v));
+        assert!(result_bool.iter().all(|&v| v));
+    }
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -277,6 +277,7 @@ mod tests {
     #[test]
     fn test_dtype_consistency_two_regions() {
         // Same pattern should produce same results across dtypes
+        let arr_u8 = array![[1u8, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
         let arr_u16 = array![[1u16, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
         let arr_i32 = array![[1i32, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
         let arr_bool = array![
@@ -285,25 +286,30 @@ mod tests {
             [false, false, true, true],
         ];
 
+        let result_u8 = find_boundaries(arr_u8.view());
         let result_u16 = find_boundaries(arr_u16.view());
         let result_i32 = find_boundaries(arr_i32.view());
         let result_bool = find_boundaries(arr_bool.view());
 
-        assert_eq!(result_u16, result_i32);
-        assert_eq!(result_u16, result_bool);
+        assert_eq!(result_u8, result_u16);
+        assert_eq!(result_u8, result_i32);
+        assert_eq!(result_u8, result_bool);
     }
 
     #[test]
     fn test_dtype_consistency_uniform() {
         // Uniform arrays should all produce no boundaries
+        let arr_u8 = array![[5u8, 5, 5], [5, 5, 5], [5, 5, 5],];
         let arr_u16 = array![[5u16, 5, 5], [5, 5, 5], [5, 5, 5],];
         let arr_i32 = array![[5i32, 5, 5], [5, 5, 5], [5, 5, 5],];
         let arr_bool = array![[true, true, true], [true, true, true], [true, true, true],];
 
+        let result_u8 = find_boundaries(arr_u8.view());
         let result_u16 = find_boundaries(arr_u16.view());
         let result_i32 = find_boundaries(arr_i32.view());
         let result_bool = find_boundaries(arr_bool.view());
 
+        assert!(result_u8.iter().all(|&v| !v));
         assert!(result_u16.iter().all(|&v| !v));
         assert!(result_i32.iter().all(|&v| !v));
         assert!(result_bool.iter().all(|&v| !v));
@@ -312,6 +318,7 @@ mod tests {
     #[test]
     fn test_dtype_consistency_center_pixel() {
         // Single different center pixel - all should be boundaries
+        let arr_u8 = array![[0u8, 0, 0], [0, 1, 0], [0, 0, 0],];
         let arr_u16 = array![[0u16, 0, 0], [0, 1, 0], [0, 0, 0],];
         let arr_i32 = array![[0i32, 0, 0], [0, 1, 0], [0, 0, 0],];
         let arr_bool = array![
@@ -320,10 +327,12 @@ mod tests {
             [false, false, false],
         ];
 
+        let result_u8 = find_boundaries(arr_u8.view());
         let result_u16 = find_boundaries(arr_u16.view());
         let result_i32 = find_boundaries(arr_i32.view());
         let result_bool = find_boundaries(arr_bool.view());
 
+        assert!(result_u8.iter().all(|&v| v));
         assert!(result_u16.iter().all(|&v| v));
         assert!(result_i32.iter().all(|&v| v));
         assert!(result_bool.iter().all(|&v| v));

--- a/src/process.rs
+++ b/src/process.rs
@@ -3,87 +3,7 @@ use ndarray::{Array2, ArrayView2};
 /// Check if a 3x3 window has non-uniform values using direct slice access.
 /// This is the fast path for interior pixels where no bounds checking is needed.
 #[inline(always)]
-fn is_boundary_interior_u16(arr: &ArrayView2<u16>, y: usize, x: usize) -> bool {
-    // SAFETY: Caller guarantees y in [1, h-2] and x in [1, w-2]
-    unsafe {
-        let first = *arr.uget((y - 1, x - 1));
-
-        // Check all 9 positions, early exit on difference
-        // Row y-1
-        if *arr.uget((y - 1, x)) != first {
-            return true;
-        }
-        if *arr.uget((y - 1, x + 1)) != first {
-            return true;
-        }
-        // Row y
-        if *arr.uget((y, x - 1)) != first {
-            return true;
-        }
-        if *arr.uget((y, x)) != first {
-            return true;
-        }
-        if *arr.uget((y, x + 1)) != first {
-            return true;
-        }
-        // Row y+1
-        if *arr.uget((y + 1, x - 1)) != first {
-            return true;
-        }
-        if *arr.uget((y + 1, x)) != first {
-            return true;
-        }
-        if *arr.uget((y + 1, x + 1)) != first {
-            return true;
-        }
-        false
-    }
-}
-
-/// Check if a 3x3 window has non-uniform values using direct slice access.
-/// This is the fast path for interior pixels where no bounds checking is needed.
-#[inline(always)]
-fn is_boundary_interior_i32(arr: &ArrayView2<i32>, y: usize, x: usize) -> bool {
-    // SAFETY: Caller guarantees y in [1, h-2] and x in [1, w-2]
-    unsafe {
-        let first = *arr.uget((y - 1, x - 1));
-
-        // Check all 9 positions, early exit on difference
-        // Row y-1
-        if *arr.uget((y - 1, x)) != first {
-            return true;
-        }
-        if *arr.uget((y - 1, x + 1)) != first {
-            return true;
-        }
-        // Row y
-        if *arr.uget((y, x - 1)) != first {
-            return true;
-        }
-        if *arr.uget((y, x)) != first {
-            return true;
-        }
-        if *arr.uget((y, x + 1)) != first {
-            return true;
-        }
-        // Row y+1
-        if *arr.uget((y + 1, x - 1)) != first {
-            return true;
-        }
-        if *arr.uget((y + 1, x)) != first {
-            return true;
-        }
-        if *arr.uget((y + 1, x + 1)) != first {
-            return true;
-        }
-        false
-    }
-}
-
-/// Check if a 3x3 window has non-uniform values using direct slice access.
-/// This is the fast path for interior pixels where no bounds checking is needed.
-#[inline(always)]
-fn is_boundary_interior_bool(arr: &ArrayView2<bool>, y: usize, x: usize) -> bool {
+fn is_boundary_interior<T: PartialEq + Copy>(arr: &ArrayView2<T>, y: usize, x: usize) -> bool {
     // SAFETY: Caller guarantees y in [1, h-2] and x in [1, w-2]
     unsafe {
         let first = *arr.uget((y - 1, x - 1));
@@ -123,47 +43,13 @@ fn is_boundary_interior_bool(arr: &ArrayView2<bool>, y: usize, x: usize) -> bool
 /// Check if an edge pixel has any neighbor with a different value.
 /// Only visits valid in-bounds neighbors (no reflection/padding).
 #[inline]
-fn is_boundary_edge_u16(arr: &ArrayView2<u16>, cy: usize, cx: usize, h: usize, w: usize) -> bool {
-    let first = arr[[cy, cx]];
-    let y_start = cy.saturating_sub(1);
-    let y_end = (cy + 1).min(h - 1);
-    let x_start = cx.saturating_sub(1);
-    let x_end = (cx + 1).min(w - 1);
-
-    for y in y_start..=y_end {
-        for x in x_start..=x_end {
-            if arr[[y, x]] != first {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Check if an edge pixel has any neighbor with a different value.
-/// Only visits valid in-bounds neighbors (no reflection/padding).
-#[inline]
-fn is_boundary_edge_i32(arr: &ArrayView2<i32>, cy: usize, cx: usize, h: usize, w: usize) -> bool {
-    let first = arr[[cy, cx]];
-    let y_start = cy.saturating_sub(1);
-    let y_end = (cy + 1).min(h - 1);
-    let x_start = cx.saturating_sub(1);
-    let x_end = (cx + 1).min(w - 1);
-
-    for y in y_start..=y_end {
-        for x in x_start..=x_end {
-            if arr[[y, x]] != first {
-                return true;
-            }
-        }
-    }
-    false
-}
-
-/// Check if an edge pixel has any neighbor with a different value.
-/// Only visits valid in-bounds neighbors (no reflection/padding).
-#[inline]
-fn is_boundary_edge_bool(arr: &ArrayView2<bool>, cy: usize, cx: usize, h: usize, w: usize) -> bool {
+fn is_boundary_edge<T: PartialEq + Copy>(
+    arr: &ArrayView2<T>,
+    cy: usize,
+    cx: usize,
+    h: usize,
+    w: usize,
+) -> bool {
     let first = arr[[cy, cx]];
     let y_start = cy.saturating_sub(1);
     let y_end = (cy + 1).min(h - 1);
@@ -181,18 +67,16 @@ fn is_boundary_edge_bool(arr: &ArrayView2<bool>, cy: usize, cx: usize, h: usize,
 }
 
 /// Detect boundary pixels where not all neighbors have the same value.
-/// This is equivalent to: max_filter(arr, 3, 'reflect') != min_filter(arr, 3, 'reflect')
-/// but computed in a single pass without intermediate arrays.
 ///
 /// A pixel is considered a boundary if any value in its 3x3 neighborhood differs
-/// from the others (i.e., min != max in the neighborhood).
+/// from the others (i.e., not all neighbors are equal).
 ///
 /// # Arguments
-/// * `arr` - 2D array view of u16 values (typically a label or thresholded image)
+/// * `arr` - 2D array view of values that support equality comparison
 ///
 /// # Returns
 /// * `Array2<bool>` - Boolean array where true indicates a boundary pixel
-pub fn find_boundaries_u16(arr: ArrayView2<u16>) -> Array2<bool> {
+pub fn find_boundaries<T: PartialEq + Copy>(arr: ArrayView2<T>) -> Array2<bool> {
     let (height, width) = arr.dim();
     let mut result = Array2::<bool>::from_elem((height, width), false);
 
@@ -201,7 +85,7 @@ pub fn find_boundaries_u16(arr: ArrayView2<u16>) -> Array2<bool> {
         // All pixels are edge pixels, use slow path
         for y in 0..height {
             for x in 0..width {
-                result[[y, x]] = is_boundary_edge_u16(&arr, y, x, height, width);
+                result[[y, x]] = is_boundary_edge(&arr, y, x, height, width);
             }
         }
         return result;
@@ -209,130 +93,24 @@ pub fn find_boundaries_u16(arr: ArrayView2<u16>) -> Array2<bool> {
 
     // Process top edge (y = 0)
     for x in 0..width {
-        result[[0, x]] = is_boundary_edge_u16(&arr, 0, x, height, width);
+        result[[0, x]] = is_boundary_edge(&arr, 0, x, height, width);
     }
 
     // Process bottom edge (y = height - 1)
     for x in 0..width {
-        result[[height - 1, x]] = is_boundary_edge_u16(&arr, height - 1, x, height, width);
+        result[[height - 1, x]] = is_boundary_edge(&arr, height - 1, x, height, width);
     }
 
     // Process left and right edges (y = 1..height-1)
     for y in 1..height - 1 {
-        result[[y, 0]] = is_boundary_edge_u16(&arr, y, 0, height, width);
-        result[[y, width - 1]] = is_boundary_edge_u16(&arr, y, width - 1, height, width);
+        result[[y, 0]] = is_boundary_edge(&arr, y, 0, height, width);
+        result[[y, width - 1]] = is_boundary_edge(&arr, y, width - 1, height, width);
     }
 
     // Process interior (fast path - no bounds checking needed)
     for y in 1..height - 1 {
         for x in 1..width - 1 {
-            result[[y, x]] = is_boundary_interior_u16(&arr, y, x);
-        }
-    }
-
-    result
-}
-
-/// Detect boundary pixels where not all neighbors have the same value.
-/// This is equivalent to: max_filter(arr, 3, 'reflect') != min_filter(arr, 3, 'reflect')
-/// but computed in a single pass without intermediate arrays.
-///
-/// A pixel is considered a boundary if any value in its 3x3 neighborhood differs
-/// from the others (i.e., min != max in the neighborhood).
-///
-/// # Arguments
-/// * `arr` - 2D array view of i32 values (typically a label image)
-///
-/// # Returns
-/// * `Array2<bool>` - Boolean array where true indicates a boundary pixel
-pub fn find_boundaries_i32(arr: ArrayView2<i32>) -> Array2<bool> {
-    let (height, width) = arr.dim();
-    let mut result = Array2::<bool>::from_elem((height, width), false);
-
-    // Handle degenerate cases
-    if height < 3 || width < 3 {
-        // All pixels are edge pixels, use slow path
-        for y in 0..height {
-            for x in 0..width {
-                result[[y, x]] = is_boundary_edge_i32(&arr, y, x, height, width);
-            }
-        }
-        return result;
-    }
-
-    // Process top edge (y = 0)
-    for x in 0..width {
-        result[[0, x]] = is_boundary_edge_i32(&arr, 0, x, height, width);
-    }
-
-    // Process bottom edge (y = height - 1)
-    for x in 0..width {
-        result[[height - 1, x]] = is_boundary_edge_i32(&arr, height - 1, x, height, width);
-    }
-
-    // Process left and right edges (y = 1..height-1)
-    for y in 1..height - 1 {
-        result[[y, 0]] = is_boundary_edge_i32(&arr, y, 0, height, width);
-        result[[y, width - 1]] = is_boundary_edge_i32(&arr, y, width - 1, height, width);
-    }
-
-    // Process interior (fast path - no bounds checking needed)
-    for y in 1..height - 1 {
-        for x in 1..width - 1 {
-            result[[y, x]] = is_boundary_interior_i32(&arr, y, x);
-        }
-    }
-
-    result
-}
-
-/// Detect boundary pixels where not all neighbors have the same value.
-/// This is equivalent to: max_filter(arr, 3, 'reflect') != min_filter(arr, 3, 'reflect')
-/// but computed in a single pass without intermediate arrays.
-///
-/// A pixel is considered a boundary if any value in its 3x3 neighborhood differs
-/// from the others (i.e., min != max in the neighborhood).
-///
-/// # Arguments
-/// * `arr` - 2D array view of bool values (typically a binary mask)
-///
-/// # Returns
-/// * `Array2<bool>` - Boolean array where true indicates a boundary pixel
-pub fn find_boundaries_bool(arr: ArrayView2<bool>) -> Array2<bool> {
-    let (height, width) = arr.dim();
-    let mut result = Array2::<bool>::from_elem((height, width), false);
-
-    // Handle degenerate cases
-    if height < 3 || width < 3 {
-        // All pixels are edge pixels, use slow path
-        for y in 0..height {
-            for x in 0..width {
-                result[[y, x]] = is_boundary_edge_bool(&arr, y, x, height, width);
-            }
-        }
-        return result;
-    }
-
-    // Process top edge (y = 0)
-    for x in 0..width {
-        result[[0, x]] = is_boundary_edge_bool(&arr, 0, x, height, width);
-    }
-
-    // Process bottom edge (y = height - 1)
-    for x in 0..width {
-        result[[height - 1, x]] = is_boundary_edge_bool(&arr, height - 1, x, height, width);
-    }
-
-    // Process left and right edges (y = 1..height-1)
-    for y in 1..height - 1 {
-        result[[y, 0]] = is_boundary_edge_bool(&arr, y, 0, height, width);
-        result[[y, width - 1]] = is_boundary_edge_bool(&arr, y, width - 1, height, width);
-    }
-
-    // Process interior (fast path - no bounds checking needed)
-    for y in 1..height - 1 {
-        for x in 1..width - 1 {
-            result[[y, x]] = is_boundary_interior_bool(&arr, y, x);
+            result[[y, x]] = is_boundary_interior(&arr, y, x);
         }
     }
 
@@ -348,7 +126,7 @@ mod tests {
     fn test_uniform_region_no_boundaries() {
         // All same value - no boundaries in interior
         let arr = array![[1u16, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1],];
-        let result = find_boundaries_u16(arr.view());
+        let result = find_boundaries(arr.view());
         // All should be false - uniform region
         assert!(result.iter().all(|&v| !v));
     }
@@ -357,7 +135,7 @@ mod tests {
     fn test_single_different_pixel() {
         // Single different pixel in center
         let arr = array![[0u16, 0, 0], [0, 1, 0], [0, 0, 0],];
-        let result = find_boundaries_u16(arr.view());
+        let result = find_boundaries(arr.view());
         // All pixels should be boundaries (all touch the different center pixel)
         assert!(result.iter().all(|&v| v));
     }
@@ -366,7 +144,7 @@ mod tests {
     fn test_two_regions() {
         // Two distinct regions
         let arr = array![[1u16, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
-        let result = find_boundaries_u16(arr.view());
+        let result = find_boundaries(arr.view());
         // Expected: boundaries at columns 1 and 2 (adjacent to the edge)
         let expected = array![
             [false, true, true, false],
@@ -383,7 +161,7 @@ mod tests {
             [false, false, true, true],
             [false, false, true, true],
         ];
-        let result = find_boundaries_bool(arr.view());
+        let result = find_boundaries(arr.view());
         let expected = array![
             [false, true, true, false],
             [false, true, true, false],
@@ -396,17 +174,17 @@ mod tests {
     fn test_small_arrays_u16() {
         // 1x1 uniform - no boundary
         let arr = array![[5u16]];
-        let result = find_boundaries_u16(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(!result[[0, 0]]);
 
         // 2x2 uniform - no boundaries
         let arr = array![[1u16, 1], [1, 1]];
-        let result = find_boundaries_u16(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(result.iter().all(|&v| !v));
 
         // 2x2 mixed - all boundaries
         let arr = array![[1u16, 2], [1, 1]];
-        let result = find_boundaries_u16(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(result.iter().all(|&v| v));
     }
 
@@ -418,7 +196,7 @@ mod tests {
     fn test_i32_uniform_region_no_boundaries() {
         // All same value - no boundaries
         let arr = array![[1i32, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1],];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(result.iter().all(|&v| !v));
     }
 
@@ -426,7 +204,7 @@ mod tests {
     fn test_i32_single_different_pixel() {
         // Single different pixel in center - all pixels are boundaries
         let arr = array![[0i32, 0, 0], [0, 1, 0], [0, 0, 0],];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(result.iter().all(|&v| v));
     }
 
@@ -434,7 +212,7 @@ mod tests {
     fn test_i32_two_regions() {
         // Two distinct regions side by side
         let arr = array![[1i32, 1, 2, 2], [1, 1, 2, 2], [1, 1, 2, 2],];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         let expected = array![
             [false, true, true, false],
             [false, true, true, false],
@@ -447,7 +225,7 @@ mod tests {
     fn test_i32_negative_values() {
         // Test with negative label values (common in some labeling schemes)
         let arr = array![[-1i32, -1, 0, 0], [-1, -1, 0, 0], [-1, -1, 0, 0],];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         let expected = array![
             [false, true, true, false],
             [false, true, true, false],
@@ -460,17 +238,17 @@ mod tests {
     fn test_i32_small_arrays() {
         // 1x1 - no boundary
         let arr = array![[5i32]];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(!result[[0, 0]]);
 
         // 2x2 uniform - no boundaries
         let arr = array![[1i32, 1], [1, 1]];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(result.iter().all(|&v| !v));
 
         // 2x2 mixed - all boundaries
         let arr = array![[1i32, 2], [1, 1]];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         assert!(result.iter().all(|&v| v));
     }
 
@@ -482,7 +260,7 @@ mod tests {
             [1, 1, 2, 2, 3, 3],
             [1, 1, 2, 2, 3, 3],
         ];
-        let result = find_boundaries_i32(arr.view());
+        let result = find_boundaries(arr.view());
         // Boundaries at label transitions: cols 1-2 and 3-4
         let expected = array![
             [false, true, true, true, true, false],
@@ -507,9 +285,9 @@ mod tests {
             [false, false, true, true],
         ];
 
-        let result_u16 = find_boundaries_u16(arr_u16.view());
-        let result_i32 = find_boundaries_i32(arr_i32.view());
-        let result_bool = find_boundaries_bool(arr_bool.view());
+        let result_u16 = find_boundaries(arr_u16.view());
+        let result_i32 = find_boundaries(arr_i32.view());
+        let result_bool = find_boundaries(arr_bool.view());
 
         assert_eq!(result_u16, result_i32);
         assert_eq!(result_u16, result_bool);
@@ -522,9 +300,9 @@ mod tests {
         let arr_i32 = array![[5i32, 5, 5], [5, 5, 5], [5, 5, 5],];
         let arr_bool = array![[true, true, true], [true, true, true], [true, true, true],];
 
-        let result_u16 = find_boundaries_u16(arr_u16.view());
-        let result_i32 = find_boundaries_i32(arr_i32.view());
-        let result_bool = find_boundaries_bool(arr_bool.view());
+        let result_u16 = find_boundaries(arr_u16.view());
+        let result_i32 = find_boundaries(arr_i32.view());
+        let result_bool = find_boundaries(arr_bool.view());
 
         assert!(result_u16.iter().all(|&v| !v));
         assert!(result_i32.iter().all(|&v| !v));
@@ -542,9 +320,9 @@ mod tests {
             [false, false, false],
         ];
 
-        let result_u16 = find_boundaries_u16(arr_u16.view());
-        let result_i32 = find_boundaries_i32(arr_i32.view());
-        let result_bool = find_boundaries_bool(arr_bool.view());
+        let result_u16 = find_boundaries(arr_u16.view());
+        let result_i32 = find_boundaries(arr_i32.view());
+        let result_bool = find_boundaries(arr_bool.view());
 
         assert!(result_u16.iter().all(|&v| v));
         assert!(result_i32.iter().all(|&v| v));


### PR DESCRIPTION
Adds an optional `boundaries_only` argument to both `mc.apply_color_map` and `mc.merge`
```python
"""
...
    boundaries_only : Sequence[bool] | bool | None, optional
        Whether to overlay only the boundary pixels of each mask instead of the full mask region.
        Can be a single bool (applies to all masks) or a sequence of bools (one per mask).
        Boundaries are detected using a 3x3 neighborhood check.
        Only supported for 2D arrays; a warning is emitted for 3D arrays and masks are applied
        normally. Default is None (False for all masks). This step does create an intermediate
        boolean array with the same shape as arr for each mask where boundaries_only is True.
"""
```

Adds internal processing function which is the functional equivalent of:
```python
from scipy import ndimage
max_filter = ndimage.maximum_filter(labels_arr, size=3, mode='reflect')
min_filter = ndimage.minimum_filter(labels_arr, size=3, mode='reflect')
boundaries = max_filter != min_filter
```

This is exposed directly as `mc.create_mask_boundaries` and also used internally within the rust backend if `boundaries_only` is True for any mask array. 


The following block shows a simple example where two different types of objects are isolated based on intensity and the overlays for the brighter objects are applied with `boundaries_only`, a higher alpha blending, and a different color.


```python
import mergechannels as mc

nuclei = ...  # images of nuclei in different phases of the cell cycle
bright_nuclei_masks = ... # instances masks of just the bright nuclei
dim_nuclei_masks = ... # instance masks of just the dim nuclei

fig, (a, b, c) = plt.subplots(1, 3, dpi=300)
for ax in (a, b, c):
    ax.axis('off')

a.imshow(bright_nuclei_masks, cmap=mc.get_mpl_cmap('glasbey'))
b.imshow(dim_nuclei_masks, cmap=mc.get_mpl_cmap('glasbey'))
c.imshow(
    mc.apply_color_map(
        arr=nuclei,
        color='Grays',  # colormap for the image
        masks=[bright_nuclei_masks, dim_nuclei_masks],  # overlay each mask array individually
        mask_colors=['betterOrange', 'betterBlue'],  # the max value of these cmaps are used
        mask_alphas=[0.8, 0.2],  # show bright nuclei in bold while dim nuclei are faded
        boundaries_only=[True, False]  # show outlines of bright nuclei, whole-masks for dim nuclei
    )
)  # add mask overlay
plt.show()
```
![Overlay multiple mask arrays with different settings](https://raw.githubusercontent.com/zacswider/README_Images/main/overlay_masks_different_settings.png)